### PR TITLE
Added callback for navigation between assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ npm install react-image-video-lightbox
 |startIndex|number|index of image/video where the lightbox should open|
 |showResourceCount|boolean|show resource count in left upper corner|
 |onCloseCallback|Function => void|callback function called when the lightbox is closed|
+|onNavigationCallback|Function => void|callback function called on navigation between assets|
 
 ### Resource Object
 |Property|Type|Description|

--- a/src/index.js
+++ b/src/index.js
@@ -40,6 +40,9 @@ class ReactImageVideoLightbox extends React.Component {
         this.handleTouchStart = this.handleTouchStart.bind(this);
         this.handleTouchMove = this.handleTouchMove.bind(this);
         this.handleTouchEnd = this.handleTouchEnd.bind(this);
+        this.onNavigationCallback = this.props.onNavigationCallback && typeof this.props.onNavigationCallback === 'function'
+            ? this.props.onNavigationCallback
+            : () => { };
     }
 
     zoomTo(scale) {
@@ -128,7 +131,7 @@ class ReactImageVideoLightbox extends React.Component {
                     swiping: false,
                     x: INITIAL_X,
                     loading: true
-                });
+                }, () => this.onNavigationCallback(currentIndex - 1));
             }, 500);
         } else {
             this.reset();
@@ -144,7 +147,7 @@ class ReactImageVideoLightbox extends React.Component {
                     swiping: false,
                     x: INITIAL_X,
                     loading: true
-                });
+                }, () => this.onNavigationCallback(currentIndex + 1));
             }, 500);
         } else {
             this.reset();


### PR DESCRIPTION
# Added callback for navigation between assets

### Description
The change allows the user to pass a callback function that fires once the `currentIndex` state value is updated. This was something I needed for a project where we tracked the impressions for the asset and had a user driven action that could be taken based on the last asset viewed.

### Technique
There are a few ways the prop could be added as optional, but I opted for the pattern I thought most fit the current codebase. Ideally, it would use `defaultProps`, but since no `propTypes` or `defaultProps` used currently, I didn't add them. I'm happy to revise to fit that model.

Additionally, the conditional check for the prop could be added in the `setState` callback, but I thought having the typeof check to avoid error was helpful. Willing to change this as well.

#### src/index.js
- Added `onNavigationCallback` to the class properties assigned via a ternary checking that `onNavigationCallback` prop is passed and that the prop is a function. If not defaults to a noop. Function expects the `currentIndex` passed to the parent component. 
- Added the `onNavigationCallback` in the `setState` callback for `swipeLeft` and `swipeRight` methods.

#### README.md
- Updated README.md to reflect the additional prop
